### PR TITLE
fixed conditional resource references (count)

### DIFF
--- a/lambda-schedule.tf
+++ b/lambda-schedule.tf
@@ -1,23 +1,23 @@
 resource "aws_lambda_permission" "allow_cloudwatch" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  statement_id = "AllowExecutionFromCloudWatch"
-  action = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.update-ips.function_name}"
-  principal = "events.amazonaws.com"
-  source_arn = "${aws_cloudwatch_event_rule.cloudflare-update-schedule.arn}"
+  count         = var.enabled == "true" ? 1 : 0
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.update-ips[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.cloudflare-update-schedule[0].arn
 }
 
 resource "aws_cloudwatch_event_rule" "cloudflare-update-schedule" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  name = "cloudflare-update-schedule"
+  count       = var.enabled == "true" ? 1 : 0
+  name        = "cloudflare-update-schedule"
   description = "Update cloudflare ips every day"
 
-  schedule_expression = "${var.schedule_expression}"
+  schedule_expression = var.schedule_expression
 }
 
 
 resource "aws_cloudwatch_event_target" "cloudflare-update-schedule" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  rule = "${aws_cloudwatch_event_rule.cloudflare-update-schedule.name}"
-  arn = "${aws_lambda_function.update-ips.arn}"
+  count = var.enabled == "true" ? 1 : 0
+  rule  = aws_cloudwatch_event_rule.cloudflare-update-schedule[0].name
+  arn   = aws_lambda_function.update-ips[0].arn
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,11 +1,11 @@
 resource "aws_cloudwatch_log_group" "lambda-log-group" {
-  name = "UpdateCloudflareIps"
-  count = "${var.enabled == "true" ? 1 : 0}"
+  name  = "UpdateCloudflareIps"
+  count = var.enabled == "true" ? 1 : 0
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  name = "lambda-cloudflare-role"
+  count              = var.enabled == "true" ? 1 : 0
+  name               = "lambda-cloudflare-role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -24,10 +24,10 @@ EOF
 }
 
 resource "aws_iam_policy" "policy" {
-  name = "lambda-cloudflare-policy"
-  count = "${var.enabled == "true" ? 1 : 0}"
+  name        = "lambda-cloudflare-policy"
+  count       = var.enabled == "true" ? 1 : 0
   description = "Allows cloudflare ip updating lambda to change security groups"
-  policy = <<EOF
+  policy      = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -61,30 +61,30 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "policy" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  role = "${aws_iam_role.iam_for_lambda.id}"
-  policy_arn = "${aws_iam_policy.policy.arn}"
+  count      = var.enabled == "true" ? 1 : 0
+  role       = aws_iam_role.iam_for_lambda[0].id
+  policy_arn = aws_iam_policy.policy[0].arn
 }
 
 data "archive_file" "lambda_zip" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  type = "zip"
+  count       = var.enabled == "true" ? 1 : 0
+  type        = "zip"
   source_file = "${path.module}/cloudflare-security-group.py"
   output_path = "${path.module}/lambda.zip"
 }
 
 resource "aws_lambda_function" "update-ips" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  function_name = "UpdateCloudflareIps"
-  filename = "${path.module}/lambda.zip"
-  source_code_hash = "${data.archive_file.lambda_zip.output_base64sha256}"
-  handler = "cloudflare-security-group.lambda_handler"
-  role = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime = "python3.6"
-  timeout = 60
+  count            = var.enabled == "true" ? 1 : 0
+  function_name    = "UpdateCloudflareIps"
+  filename         = "${path.module}/lambda.zip"
+  source_code_hash = data.archive_file.lambda_zip[0].output_base64sha256
+  handler          = "cloudflare-security-group.lambda_handler"
+  role             = aws_iam_role.iam_for_lambda[0].arn
+  runtime          = "python3.6"
+  timeout          = 60
   environment {
-    variables {
-      SECURITY_GROUP_ID = "${var.security_group_id}"
+    variables = {
+      SECURITY_GROUP_ID = var.security_group_id
     }
   }
 }

--- a/securitygroup.tf
+++ b/securitygroup.tf
@@ -20,23 +20,23 @@
 //}
 
 resource "aws_security_group_rule" "egress_http" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  type = "egress"
+  count     = var.enabled == "true" ? 1 : 0
+  type      = "egress"
   from_port = 80
-  to_port = 80
-  protocol = "tcp"
+  to_port   = 80
+  protocol  = "tcp"
   cidr_blocks = [
-    "0.0.0.0/0"]
-  security_group_id = "${var.security_group_id}"
+  "0.0.0.0/0"]
+  security_group_id = var.security_group_id
 }
 
 resource "aws_security_group_rule" "egress_https" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  type = "egress"
+  count     = var.enabled == "true" ? 1 : 0
+  type      = "egress"
   from_port = 443
-  to_port = 443
-  protocol = "tcp"
+  to_port   = 443
+  protocol  = "tcp"
   cidr_blocks = [
-    "0.0.0.0/0"]
-  security_group_id = "${var.security_group_id}"
+  "0.0.0.0/0"]
+  security_group_id = var.security_group_id
 }


### PR DESCRIPTION
This Pull requet to fix issues that I encountered with `count` attribute.

Fix error of type:
```
Error: Missing resource instance key

  on .terraform/modules/cloudflare-ips/lambda.tf line 65, in resource "aws_iam_role_policy_attachment" "policy":
  65:   role = "${aws_iam_role.iam_for_lambda.id}"

Because aws_iam_role.iam_for_lambda has "count" set, its attributes must be
accessed on specific instances.

For example, to correlate with indices of a referring resource, use:
    aws_iam_role.iam_for_lambda[count.index]
```