### PR TITLE
Upgrade lambda python runtime from 3.6 to 3.9

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -80,7 +80,7 @@ resource "aws_lambda_function" "update-ips" {
   source_code_hash = data.archive_file.lambda_zip[0].output_base64sha256
   handler          = "cloudflare-security-group.lambda_handler"
   role             = aws_iam_role.iam_for_lambda[0].arn
-  runtime          = "python3.6"
+  runtime          = "python3.9"
   timeout          = 60
   environment {
     variables = {


### PR DESCRIPTION
I received this notice from AWS last month: 

> We are ending support for Python 3.6 in AWS Lambda. This follows Python 3.6 End-Of-Life (EOL) reached on December 23, 2021.
> 
> As described in the Lambda runtime support policy, end of support for language runtimes in Lambda happens in two stages. Starting July 18, 2022, Lambda will no longer apply security patches and other updates to the Python 3.6 runtime used by Lambda functions, and functions using Python 3.6 will no longer be eligible for technical support. In addition, you will no longer be able to create new Lambda functions using the Python 3.6 runtime. Starting August 17, 2022, you will no longer be able to update existing functions using the Python 3.6 runtime.
> 
> We recommend that you upgrade your existing Python 3.6 functions to Python 3.9 before August 17, 2022.
> 
> End of support does not impact function execution. Your functions will continue to run. However, they will be running on an unsupported runtime which is no longer maintained or patched by the AWS Lambda team.
> 
> The following command shows how to use the AWS CLI to list all functions in a specific region using Python 3.6. To find all such functions in your account, repeat this command for each region:
> 
>     aws lambda list-functions --function-version ALL --region us-east-1 --output text --query "Functions[?Runtime=='python3.6'].FunctionArn"